### PR TITLE
Fix issue #48 analog to dadler's fix for thumbnail-zoom

### DIFF
--- a/chrome/content/tabscope/overlay.xul
+++ b/chrome/content/tabscope/overlay.xul
@@ -9,7 +9,7 @@
 	<script type="application/x-javascript" src="chrome://tabscope/content/overlay.js" />
 
 	<popupset id="mainPopupSet">
-		<panel id="tabscope-popup" noautofocus="true" noautohide="true"
+		<panel id="tabscope-popup" noautofocus="true" noautohide="true" level="top"
 		       consumeoutsideclicks="false"
 		       onpopupshowing="TabScope.handleEvent(event);"
 		       onpopupshown="TabScope.handleEvent(event);"


### PR DESCRIPTION
dadler's commit: https://github.com/dadler/thumbnail-zoom/commit/683869e1e8c0698fff4010a43d9ccf45d4e70ada

An unindented switch might still happen, while the fullscreen-animation is still ongoing and but after that Tab Scope will not cause a switch away from the current space / virtual desktop.
